### PR TITLE
Enable ping behavior

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2822,6 +2822,7 @@ dependencies = [
  "libp2p-mdns",
  "libp2p-metrics",
  "libp2p-noise",
+ "libp2p-ping",
  "libp2p-quic",
  "libp2p-swarm",
  "libp2p-tcp",
@@ -3036,6 +3037,7 @@ dependencies = [
  "libp2p-identify",
  "libp2p-identity",
  "libp2p-kad",
+ "libp2p-ping",
  "libp2p-swarm",
  "pin-project",
  "prometheus-client",
@@ -3065,6 +3067,24 @@ dependencies = [
  "tracing",
  "x25519-dalek",
  "zeroize",
+]
+
+[[package]]
+name = "libp2p-ping"
+version = "0.44.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76b94ee41bd8c294194fe608851e45eb98de26fe79bc7913838cbffbfe8c7ce2"
+dependencies = [
+ "either",
+ "futures",
+ "futures-timer",
+ "instant",
+ "libp2p-core",
+ "libp2p-identity",
+ "libp2p-swarm",
+ "rand",
+ "tracing",
+ "void",
 ]
 
 [[package]]
@@ -3348,6 +3368,7 @@ dependencies = [
  "envconfig",
  "eyre",
  "futures",
+ "futures-ticker",
  "futures-util",
  "libp2p",
  "mini-moka",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ libp2p = { version = "0.53.2", features = [
     "kad",
     "gossipsub",
     "identify",
+    "ping",
     "dns",
 ] }
 tokio = { version = "1.36.0", features = ["full"] }
@@ -41,6 +42,7 @@ once_cell = "1.19.0"
 rand = "0.8.5"
 runit = "0.1.0"
 futures-util = "0.3"
+futures-ticker = "0.0.3"
 mini-moka = "0.10.3"
 axum = "0.7.5"
 reqwest = "0.12.3"

--- a/src/p2p.rs
+++ b/src/p2p.rs
@@ -21,6 +21,7 @@ pub struct MintpoolBehaviour {
     gossipsub: gossipsub::Behaviour,
     kad: kad::Behaviour<MemoryStore>,
     identify: libp2p::identify::Behaviour,
+    ping: libp2p::ping::Behaviour,
 }
 
 pub struct SwarmController {
@@ -110,6 +111,7 @@ impl SwarmController {
                         "mintpool/0.1.0".to_string(),
                         public_key,
                     )),
+                    ping: libp2p::ping::Behaviour::new(libp2p::ping::Config::new()),
                 }
             })?
             .with_swarm_config(|c| c.with_idle_connection_timeout(Duration::from_secs(60)))
@@ -225,6 +227,10 @@ impl SwarmController {
                 }
 
                 tracing::info!("Connection established with peer: {:?}", peer_id);
+            }
+
+            SwarmEvent::ConnectionClosed { peer_id, cause, .. } => {
+                tracing::info!("Connection closed: {:?}, cause: {:?}", peer_id, cause);
             }
 
             SwarmEvent::OutgoingConnectionError { peer_id, error, .. } => {


### PR DESCRIPTION
The ping behavior appears to regularly refresh connections to known peers. This fixes the issue we've seen where peers that had been disconnected would not be added to the gossip peers again.