### PR TITLE
Don't use autonat or relay if relay server is enabled

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -79,8 +79,8 @@ pub struct Config {
     #[envconfig(from = "SYNC_LOOKBACK_HOURS", default = "6")]
     pub sync_lookback_hours: u64,
 
-    #[envconfig(from = "ENABLE_RELAY", default = "false")]
-    pub enable_relay: bool,
+    #[envconfig(from = "ENABLE_RELAY_SERVER", default = "false")]
+    pub enable_relay_server: bool,
 }
 
 impl Config {
@@ -107,7 +107,7 @@ impl Config {
             rate_limit_rps: 1,
             boot_nodes: BootNodes::None,
             sync_lookback_hours: 6,
-            enable_relay: false,
+            enable_relay_server: false,
         }
     }
 }


### PR DESCRIPTION
Autonat is sometimes causing issues for our server nodes. If we know that we have an externally reachable address, we shouldn't rely on autonat to confirm it.

The way the implementation works autonat will always only try to connect to addresses that it can observe from the connecting node, which means it might not confirm the supposed external address of the server node.